### PR TITLE
Don't modify $EASYRSA_EXTRA_EXTS in gen_req()

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -522,7 +522,7 @@ Continuing with key generation will replace this key."
 	# When EASYRSA_EXTRA_EXTS is defined, append it to openssl's [req] section:
 	if [ -n "$EASYRSA_EXTRA_EXTS" ]; then
 		# Setup & insert the extra ext data keyed by a magic line
-		EASYRSA_EXTRA_EXTS="
+		EASYRSA_EXTRA_EXTS_REQ="
 req_extensions = req_extra
 [ req_extra ]
 $EASYRSA_EXTRA_EXTS"
@@ -531,7 +531,7 @@ $EASYRSA_EXTRA_EXTS"
 	{ while ( getline<"/dev/stdin" ) {print} next }
  {print}
 }'
-		print "$EASYRSA_EXTRA_EXTS" | \
+		print "$EASYRSA_EXTRA_EXTS_REQ" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
 			> "$EASYRSA_TEMP_FILE" \
 			|| die "Copying SSL config to temp file failed"


### PR DESCRIPTION
$EASYRSA_EXTRA_EXTS shouldn't be modified when creating certificate request, otherwise subsequent call to sign_req() will fail. This caused build-full-{client,server} to fail when --subject-alt-name is supplied.

Fixes issue #25.
