### PR TITLE
Pass the flag -utf8 to openssl to interpret field values as UTF-8.

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -451,7 +451,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	# Default CN only when not in global EASYRSA_BATCH mode:
 	[ $EASYRSA_BATCH ] && opts="$opts -batch" || export EASYRSA_REQ_CN="Easy-RSA CA"
 	# create the CA keypair:
-	"$EASYRSA_OPENSSL" req -new -newkey $EASYRSA_ALGO:"$EASYRSA_ALGO_PARAMS" \
+	"$EASYRSA_OPENSSL" req -utf8 -new -newkey $EASYRSA_ALGO:"$EASYRSA_ALGO_PARAMS" \
 		-config "$EASYRSA_SSL_CONF" -keyout "$out_key" -out "$out_file" $opts || \
 		die "Failed to build the CA"
 
@@ -540,7 +540,7 @@ $EASYRSA_EXTRA_EXTS"
 
 	# generate request
 	[ $EASYRSA_BATCH ] && opts="$opts -batch"
-	"$EASYRSA_OPENSSL" req -new -newkey $EASYRSA_ALGO:"$EASYRSA_ALGO_PARAMS" \
+	"$EASYRSA_OPENSSL" req -utf8 -new -newkey $EASYRSA_ALGO:"$EASYRSA_ALGO_PARAMS" \
 		-config "$EASYRSA_SSL_CONF" -keyout "$key_out" -out "$req_out" $opts \
 		|| die "Failed to generate request"
 	notice "\
@@ -625,7 +625,7 @@ Failed to create temp extension file (bad permissions?) at:
 $EASYRSA_TEMP_FILE"
 
 	# sign request
-	"$EASYRSA_OPENSSL" ca -in "$req_in" -out "$crt_out" -config "$EASYRSA_SSL_CONF" \
+	"$EASYRSA_OPENSSL" ca -utf8 -in "$req_in" -out "$crt_out" -config "$EASYRSA_SSL_CONF" \
 		-extfile "$EASYRSA_TEMP_FILE" -days $EASYRSA_CERT_EXPIRE -batch $opts \
 		|| die "signing failed (openssl output above may have more detail)"
 	notice "\
@@ -704,7 +704,7 @@ $(display_dn x509 "$crt_in")
 Unable to revoke as no certificate was found. Certificate was expected
 at: $crt_in"
 
-	"$EASYRSA_OPENSSL" ca -revoke "$crt_in" -config "$EASYRSA_SSL_CONF" || die "\
+	"$EASYRSA_OPENSSL" ca -utf8 -revoke "$crt_in" -config "$EASYRSA_SSL_CONF" || die "\
 Failed to revoke certificate: revocation command failed."
 
 	notice "\
@@ -721,7 +721,7 @@ gen_crl() {
 	verify_ca_init
 
 	local out_file="$EASYRSA_PKI/crl.pem"
-	"$EASYRSA_OPENSSL" ca -gencrl -out "$out_file" -config "$EASYRSA_SSL_CONF" || die "\
+	"$EASYRSA_OPENSSL" ca -utf8 -gencrl -out "$out_file" -config "$EASYRSA_SSL_CONF" || die "\
 CRL Generation failed.
 "
 
@@ -887,7 +887,7 @@ error messages."
 update_db() {
 	verify_ca_init
 
-	"$EASYRSA_OPENSSL" ca -updatedb -config "$EASYRSA_SSL_CONF" || die "\
+	"$EASYRSA_OPENSSL" ca -utf8 -updatedb -config "$EASYRSA_SSL_CONF" || die "\
 Failed to perform update-db: see above for related openssl errors."
 	return 0
 } # => update_db()


### PR DESCRIPTION
By default, field values are interpreted as ASCII but UTF-8 would be a
more reasonable default. Without the -utf8 flag, non-ASCII text gets
garbled without warning. ASCII text works fine either way.
